### PR TITLE
add blink-search-grep-file-ignore-dirs

### DIFF
--- a/backend/blink-search-grep-file.el
+++ b/backend/blink-search-grep-file.el
@@ -96,6 +96,8 @@
    (blink-search-grep-file-do file line column)
    ))
 
+(defvar blink-search-grep-ignore-dirs '("node_modules" "__pycache__" "dist"))
+
 (provide 'blink-search-grep-file)
 
 ;;; blink-search-grep-file.el ends here

--- a/backend/search_current_buffer.py
+++ b/backend/search_current_buffer.py
@@ -47,7 +47,7 @@ class SearchCurrentBuffer(Search):
             f.write(self.buffer_content)
         
     def search_match(self, prefix):
-        if os.path.exists(self.buffer_temp_path):
+        if os.path.exists(self.buffer_temp_path) and len(prefix) > 0:
             command_string = "rg -S --json --max-columns 300 '{}' {}".format(prefix, self.buffer_temp_path)
             lines = self.get_process_result(command_string)
             

--- a/backend/search_grep_file.py
+++ b/backend/search_grep_file.py
@@ -22,7 +22,7 @@
 import os
 import json
 
-from core.utils import eval_in_emacs, message_emacs, get_project_path    # type: ignore
+from core.utils import eval_in_emacs, get_emacs_var, message_emacs, get_project_path    # type: ignore
 from core.search import Search    # type: ignore
 
 class SearchGrepFile(Search):
@@ -33,11 +33,16 @@ class SearchGrepFile(Search):
         
     def init_dir(self, search_dir):
         self.search_path = get_project_path(search_dir)
+        self.ignore_dirs = get_emacs_var("blink-search-grep-file-ignore-dirs")
         
     def search_match(self, prefix):
         prefix = prefix.replace("*", "")
         if len(prefix.split()) > 0:
             command_string = "rg -S --json --max-columns 300 '{}'".format(".*".join(prefix.split()))
+            if len(self.ignore_dirs) > 0:
+                ignore_pattern = ["-g !\"{}\"".format(d) for d in self.ignore_dirs]
+                command_string = "{} {}".format(command_string, " ".join(ignore_pattern))
+        
             lines = self.get_process_result(command_string, self.search_path)
             
             results = []

--- a/blink-search.el
+++ b/blink-search.el
@@ -536,7 +536,7 @@ blink-search will search current symbol if you call this function with `C-u' pre
   `(space :align-to (,xpos)))
 
 (defun blink-search-render-candidate (backend-name candidate candidate-max-length)
-  (let ((candidate-length (string-width candidate)))
+  (let ((candidate-length (length candidate)))
     (cond ((string-equal backend-name "Recent File")
            (file-name-nondirectory candidate))
           ((member backend-name '("Current Buffer" "EAF Browser History" "Grep File"))


### PR DESCRIPTION
1. use length instead of string-width (substring may raise args-out-of-range error)

2. add blink-search-grep-file-ignore-dirs