### PR TITLE
Feat syntax highlight for searching current buffer

### DIFF
--- a/blink-search.el
+++ b/blink-search.el
@@ -708,6 +708,19 @@ blink-search will search current symbol if you call this function with `C-u' pre
                        candidate-prefix-length
                        candidate-line)
 
+                  ;; keep syntax highlight
+                  (when (and (equal backend "Current Buffer")
+                             (string-match "^\\([[:digit:]]+\\):\\([[:digit:]]+\\): " candidate))
+                    (let ((line (string-to-number  (match-string 1 candidate)))
+                          (char (string-to-number  (match-string 2 candidate))))
+                      (with-current-buffer blink-search-start-buffer
+                        (save-excursion
+                          (goto-line line)
+                          (setq candidate
+                                (format "%s:%s: %s"
+                                        line char
+                                        (buffer-substring (line-beginning-position) (line-end-position))))))))
+
                   (setq candidate-prefix
                         (concat
                          icon-text
@@ -752,7 +765,10 @@ blink-search will search current symbol if you call this function with `C-u' pre
                                  (backward-char 1)
                                  (setq match-end-point (+ (point) candidate-prefix-length))
                                  (list match-start-point match-end-point)))))
-                        (add-face-text-property (nth 0 match-column) (nth 1 match-column) 'font-lock-type-face 'append candidate-line)
+                        (if (equal backend "Current Buffer")
+                            ;; highlight matches for current buffer
+                            (add-face-text-property (nth 0 match-column) (nth 1 match-column) 'blink-search-select-face nil candidate-line)
+                          (add-face-text-property (nth 0 match-column) (nth 1 match-column) 'font-lock-type-face 'append candidate-line))
                         )))
 
                   (when (equal candidate-index candidate-select-index)


### PR DESCRIPTION
Maybe we could highlight the syntax for searching the current buffer?
before
![1742031668430975_ pic_hd](https://user-images.githubusercontent.com/19282154/201667661-11759463-ef05-4724-ae14-26837b49030c.jpg)
after
![1741921668421818_ pic_hd](https://user-images.githubusercontent.com/19282154/201667595-e11edfbc-6f13-47c2-b2cf-dc1a0fd75eb0.jpg)