### PR TITLE
Fix bug that doesn't work with tramp's buffer

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -134,10 +134,13 @@ def get_emacs_func_result(method_name, *args):
 
 def get_command_result(command_string, cwd=None):
     import subprocess
-    process = subprocess.Popen(command_string, cwd=cwd, shell=True, text=True,
-                               stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                               encoding="utf-8")
-    
+    try:
+        process = subprocess.Popen(command_string, cwd=cwd, shell=True, text=True,
+                                   stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                   encoding="utf-8")
+    except:
+        return ""
+
     ret = process.wait()
     if ret == 0:
         return "".join(process.stdout.readlines()).strip()    # type: ignore


### PR DESCRIPTION
The error log is shown below:
```
ERROR:epc:FileNotFoundError(2, "No such file or directory: '/scp:grimoirelab-1.gitee:/home/git/compass-web-service/'")
ERROR:epc:Unexpected error
Traceback (most recent call last):
  File "/home/ef/.local/lib/python3.7/site-packages/epc/handler.py", line 242, in _handle
    reply = handler(uid, *args)
  File "/home/ef/.local/lib/python3.7/site-packages/epc/utils.py", line 51, in new_method
    ret = method(self, *args, **kwds)
  File "/home/ef/.local/lib/python3.7/site-packages/epc/handler.py", line 265, in _handle_call
    return ['return', uid, func(*args)]
  File "/home/ef/.emacs.d/site-lisp/blink-search/blink_search.py", line 494, in search
    self.search_init_search_dir(start_directory)
  File "/home/ef/.emacs.d/site-lisp/blink-search/blink_search.py", line 436, in search_init_search_dir
    getattr(backend_var, "init_dir")(start_dir)
  File "/home/ef/.emacs.d/site-lisp/blink-search/backend/search_find_file.py", line 36, in init_dir
    self.search_path = get_project_path(search_dir)
  File "/home/ef/.emacs.d/site-lisp/blink-search/core/utils.py", line 110, in get_project_path
    git_project_path = get_command_result("git rev-parse --show-toplevel", search_path)
  File "/home/ef/.emacs.d/site-lisp/blink-search/core/utils.py", line 139, in get_command_result
    encoding="utf-8")
  File "/home/ef/miniconda3/lib/python3.7/subprocess.py", line 800, in __init__
    restore_signals, start_new_session)
  File "/home/ef/miniconda3/lib/python3.7/subprocess.py", line 1551, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/scp:grimoirelab-1.gitee:/home/git/compass-web-service/': '/scp:grimoirelab-1.gitee:/home/git/compass-web-service/'
ERROR:epc:FileNotFoundError(2, "No such file or directory: '/scp:grimoirelab-1.gitee:/home/git/compass-web-service/'")
```