### PR TITLE
Improve the search experience and removing the spaces at the code.

### DIFF
--- a/backend/search_find_file.py
+++ b/backend/search_find_file.py
@@ -2,20 +2,20 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (C) 2022 Andy Stewart
-# 
+#
 # Author:     Andy Stewart <lazycat.manatee@gmail.com>
 # Maintainer: <lazycat.manatee@gmail.com> <lazycat.manatee@gmail.com>
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -26,26 +26,26 @@ from core.utils import eval_in_emacs, message_emacs, get_project_path    # type:
 from core.search import Search    # type: ignore
 
 class SearchFindFile(Search):
-    
+
     def __init__(self, backend_name, message_queue) -> None:
         Search.__init__(self, backend_name, message_queue)
         self.sub_process = None
-        
+
     def init_dir(self, search_dir):
         self.search_dir = search_dir
         self.search_path = get_project_path(search_dir)
-        
+
     def search_match(self, prefix):
         prefix = prefix.replace("*", "")
         if len(prefix.split()) > 0:
             if shutil.which("fd"):
-                command_list = ["fd", "--regex",".*".join(prefix.split()), "--search-path", self.search_path]
+                command_list = ["fd", "--regex", ".*".join(prefix.split()), "--full-path", "--search-path", self.search_path]
             elif shutil.which("fdfind"):
-                command_list = ["fdfind", ".*".join(prefix.split()), "--search-path", self.search_path]
+                command_list = ["fdfind", ".*".join(prefix.split()), "--full-path", "--search-path", self.search_path]
             else:
                 return []
-            results = self.get_process_result(command_list)        
-            
+            results = self.get_process_result(command_list)
+
             return list(map(lambda p: os.path.relpath(p, self.search_path), results))
         else:
             return os.listdir(self.search_dir)
@@ -57,7 +57,7 @@ class SearchFindFile(Search):
         path = os.path.join(self.search_path, candidate)
         eval_in_emacs("kill-new", path)
         message_emacs("Copy: {}".format(path))
-        
+
     def parent(self, candidate):
         eval_in_emacs("blink-search-open-file", os.path.dirname(os.path.join(self.search_path, candidate)))
 
@@ -67,6 +67,6 @@ class SearchFindFile(Search):
             continue_path = candidate_path
         else:
             continue_path = os.path.dirname(candidate_path)
-        
+
         eval_in_emacs("blink-search-continue-search", continue_path)
 

--- a/blink-search.el
+++ b/blink-search.el
@@ -268,8 +268,9 @@ Setting this to nil or 0 will turn off the indicator."
 
 (defun blink-search-call-async (method &rest args)
   "Call Python EPC function METHOD and ARGS asynchronously."
-  (blink-search-deferred-chain
-    (blink-search-epc-call-deferred blink-search-epc-process (read method) args)))
+  (when (blink-search-epc-live-p blink-search-epc-process)
+    (blink-search-deferred-chain
+      (blink-search-epc-call-deferred blink-search-epc-process (read method) args))))
 
 (defun blink-search-get-theme-mode ()
   "Get theme mode, dark or light."


### PR DESCRIPTION
Add `--full-path` param for `fd` command, in order to apply the pattern to match full path of file (include dir path).

Before adjustment:
![image](https://github.com/manateelazycat/blink-search/assets/13914416/d5d99af4-4eac-45b2-9dbc-b669a6554fd1)


After adjustment:

![image](https://github.com/manateelazycat/blink-search/assets/13914416/686624cc-0100-4536-b2e3-4ee545c82044)
